### PR TITLE
Fix session check and abort early

### DIFF
--- a/plugin/tmuxjump.vim
+++ b/plugin/tmuxjump.vim
@@ -20,7 +20,7 @@ function! tmuxjump#jump_to_file(fileWithPos) abort
 endfunction
 
 function tmuxjump#grep_tmux(pattern) abort
-  let l:is_in_tmux = system('[[ "$TERM" =~ "screen" && "$TERM_PROGRAM" == "tmux" ]] && echo "1"')
+  let l:is_in_tmux = has_key(environ(), 'TMUX')
   if !l:is_in_tmux
     echohl WarningMsg
     echo "TmuxJump.vim: Not in tmux session"

--- a/plugin/tmuxjump.vim
+++ b/plugin/tmuxjump.vim
@@ -25,7 +25,7 @@ function tmuxjump#grep_tmux(pattern) abort
     echohl WarningMsg
     echo "TmuxJump.vim: Not in tmux session"
     echohl None
-    return
+    return []
   endif
 
   let l:capturedFiles = system('sh '. g:script_path . ' '. a:pattern)
@@ -33,7 +33,7 @@ function tmuxjump#grep_tmux(pattern) abort
     echohl WarningMsg
     echo "TmuxJump.vim: Found no file paths"
     echohl None
-    return
+    return []
   endif
 
   let l:list = uniq(reverse(split(l:capturedFiles, '\n')))
@@ -42,6 +42,9 @@ endfunction
 
 function! tmuxjump#capture_and_jump(pattern, bang) abort
   let l:list = tmuxjump#grep_tmux(a:pattern)
+  if len(l:list) == 0
+      return 
+  endif
   call tmuxjump#jump_to_file(l:list[0])
 endfunction
 
@@ -62,6 +65,9 @@ endfunction
 
 function! tmuxjump#capture_and_list_file(pattern, bang) abort
   let l:list = tmuxjump#grep_tmux(a:pattern)
+  if len(l:list) == 0
+      return
+  endif
   if get(g:, 'tmuxjump_telescope')
     call tmuxjump#open_telescope(l:list)
   else


### PR DESCRIPTION
First of all, thanks for this plugin, I've been looking for something like this for a while, but only just stumbled upon it today.

I had an issue where TERM wasn't set to any of the values checked on the check determining if it was a tmux session or not. Checking if the environment has the TMUX variable set should be more deterministic.

Also added a check for `l:list` being empty. If it came back empty after grepping, telescope would complain about calling `ipairs` with a number instead of something iterable.